### PR TITLE
Polish documentation and harden auth tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,75 @@
-# automart2025
-Auto Mart is an online marketplace for automobiles of diverse makes, model or body type. With Auto Mart, users can sell their cars or buy from trusted dealerships or private sellers
+# AutoMart 2025
 
-[![Coverage Status](https://coveralls.io/repos/github/MalcolmMark/automart2025/badge.svg?branch=develop)](https://coveralls.io/github/MalcolmMark/automart2025?branch=develop) 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=MalcolmMark_automart2025&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=MalcolmMark_automart2025) [![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=MalcolmMark_automart2025)](https://sonarcloud.io/summary/new_code?id=MalcolmMark_automart2025) [![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=MalcolmMark_automart2025)
+AutoMart is an online marketplace for automobiles across different makes, models, and body types. The platform supports private sellers and dealerships, and allows buyers to discover and purchase listed vehicles.
 
+## Project Status
+This repository currently includes:
+- A Flask backend API (`backend/`) with authentication endpoints.
+- Static UI prototype pages (`automart/UI/`).
 
-# Required Features
-- User can sign up.
-- User can sign in.
-- User (seller) can post a car sale advertisement.
-- User (buyer) can make a purchase order.
-- User (buyer) can update the price of his/her purchase order.
-- User (seller) can mark his/her posted AD as sold.
-- User (seller) can update the price of his/her posted AD.
-- User can view a specific car.
-- User can view all unsold cars.
-- User can view all unsold cars within a price range.
-- Admin can delete a posted AD record.
-- Admin can view all posted ads whether sold or unsold.
+## Core Features (Planned / In Scope)
+- User sign up and sign in.
+- Seller can post a car sale advertisement.
+- Buyer can place a purchase order.
+- Buyer can update the price of a purchase order.
+- Seller can mark a posted ad as sold.
+- Seller can update the price of a posted ad.
+- Users can view a specific car.
+- Users can view all unsold cars.
+- Users can filter unsold cars by price range.
+- Admin can delete a posted ad.
+- Admin can view all posted ads (sold and unsold).
 
-# Technologies
-- Python, Flask 
+## Tech Stack
+- Python 3.10+
+- Flask
+- Flask-JWT-Extended
+- Pytest
 
+## Getting Started
 
-# Requirements and Installation
- To install and run this project you would need to have listed stack installed:
+### 1) Clone the repository
+```bash
+git clone https://github.com/MalcolmMark/automart2025.git
+cd automart2025
+```
 
-# Node Js To run:
+### 2) Set up backend dependencies
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
 
-- Make sure you run the project admin and user in the different browsers of your choice
-    git clone (In Gitbash press shift + insert to put my repo url)
-    see this: 
-    
-    git clone <https://github.com/MalcolmMark/Automart.git>
-    cd Automart
+### 3) Configure environment variables
+```bash
+export JWT_SECRET_KEY="replace-with-a-long-random-secret"
+export ADMIN_SIGNUP_CODE="replace-with-admin-signup-code"
+```
 
+### 4) Run the backend
+```bash
+flask --app app:create_app run --debug
+```
 
-# Testing
+The API will be available at `http://127.0.0.1:5000`.
 
+## Running Tests
+From the `backend/` directory:
+```bash
+pytest -q
+```
 
-# API-END POINTS
-. V1
+## API Endpoints (Current)
+- `GET /` — health check.
+- `POST /api/v1/auth/signup` — register user.
+- `POST /api/v1/auth/signin` — authenticate user.
 
+## UI Prototype
+Static prototype pages are in:
+- `automart/UI/`
 
-# Pivotal Tracker Stories
-
-    https://www.pivotaltracker.com/n/projects/2349070
-
-
-# Template UI
-
-    Check out my site published / hosted at https://malcolmmark.github.io/automart2025/
-
-# API
-
-    Automart API is still in verion 1 (V1) and is hosted on Heroku at https://
-
-# API Documentation
-
-    https://
-
-# Author
-
-    Malcolm Mark Okabo
-    email: malcolmmarkokabo@gmail.com
+## Author
+Malcolm Mark Okabo  
+Email: `malcolmmarkokabo@gmail.com`

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -5,7 +5,10 @@ import pathlib
 import pytest
 
 # Ensure env vars exist for tests
-os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret")
+os.environ.setdefault(
+    "JWT_SECRET_KEY",
+    "test-jwt-secret-key-with-minimum-32-bytes",
+)
 os.environ.setdefault("ADMIN_SIGNUP_CODE", "test-admin-code")
 
 # Ensure the backend root (where app.py lives) is on sys.path
@@ -42,7 +45,6 @@ def test_signup_success(client):
         "last_name": "User",
         "password": "123456",
         "address": "Kampala",
-        # no admin_code → normal user
     }
     res = client.post("/api/v1/auth/signup", json=payload)
     assert res.status_code == 201
@@ -60,11 +62,9 @@ def test_signup_duplicate_email(client):
         "password": "123456",
         "address": "Kampala",
     }
-    # First signup
     res1 = client.post("/api/v1/auth/signup", json=payload)
     assert res1.status_code == 201
 
-    # Second signup with same email should fail
     res2 = client.post("/api/v1/auth/signup", json=payload)
     assert res2.status_code == 400
     data = res2.get_json()
@@ -72,21 +72,19 @@ def test_signup_duplicate_email(client):
 
 
 def test_signin_success_as_admin(client):
-    # sign up first with valid admin_code
     signup_payload = {
         "email": "login@example.com",
         "first_name": "Login",
         "last_name": "User",
         "password": "supersecret",
         "address": "Kampala",
-        "admin_code": "test-admin-code",  # matches ADMIN_SIGNUP_CODE
+        "admin_code": "test-admin-code",
     }
     res_signup = client.post("/api/v1/auth/signup", json=signup_payload)
     assert res_signup.status_code == 201
     signup_data = res_signup.get_json()
     assert signup_data["user"]["is_admin"] is True
 
-    # then login with same credentials
     signin_payload = {
         "email": "login@example.com",
         "password": "supersecret",
@@ -99,14 +97,17 @@ def test_signin_success_as_admin(client):
 
 
 def test_signin_invalid_credentials(client):
-    # no user created
     payload = {"email": "nosuchuser@example.com", "password": "wrong"}
     res = client.post("/api/v1/auth/signin", json=payload)
     assert res.status_code == 400
     data = res.get_json()
     assert "Invalid email or password" in data["error"]
     assert "access_token" not in data
-    payload = {"email": "sales@eclipsebiosciences.com", "password": "incorect"}
-    payload = {"email": "", "password": "incorect"} 
-#current point i stopped
-#Codedex.dex
+
+
+def test_signin_missing_email_or_password(client):
+    payload = {"email": "", "password": "incorrect"}
+    res = client.post("/api/v1/auth/signin", json=payload)
+    assert res.status_code == 400
+    data = res.get_json()
+    assert data["error"] == "Email and password are required"


### PR DESCRIPTION
### Motivation
- Provide a clearer, more professional project README so contributors can quickly onboard and run the project.
- Remove unfinished / noisy lines from the auth test module to improve maintainability and test clarity.
- Eliminate test-time JWT weak-key warnings by using a sufficiently long test secret and add validation coverage for signin input requirements.

### Description
- Rewrote the root `README.md` to include project status, core features, tech stack, setup and run instructions, environment configuration, testing instructions, and current API endpoints.
- Cleaned up `backend/tests/test_auth.py` by removing stray lines and comments and restructuring the file for clarity.
- Replaced the test JWT secret with a 32+ byte value via `os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-with-minimum-32-bytes")` to avoid insecure key warnings.
- Added a new test `test_signin_missing_email_or_password` that asserts a `400` response and the message `"Email and password are required"` when signin payloads are missing required fields.

### Testing
- Ran `cd backend && pytest -q` and all tests passed (`6 passed`).
- Local test runs confirm no JWT weak-key warnings with the updated test secret and the new signin validation test is exercised by the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15727f2b883329a54dd2d5720af23)