### PR TITLE
Improve marketplace UX and backend query efficiency

### DIFF
--- a/automart/UI/marketplace.html
+++ b/automart/UI/marketplace.html
@@ -4,237 +4,168 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Marketplace - AutoMart</title>
-
-  <!-- Load shared styles -->
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div class="page-shell">
+    <header>
+      <div class="brand">AutoMart</div>
+      <nav>
+        <a href="signup.html">Sign Up</a>
+        <a href="signin.html">Sign In</a>
+        <a href="post_car.html">Post Ad</a>
+        <a href="marketplace.html" class="active">Marketplace</a>
+        <a href="orders.html">Orders</a>
+        <a href="admin.html">Admin</a>
+      </nav>
+    </header>
 
-  <!-- DEBUG marker so you know you're loading THIS file -->
-  <p style="color:yellow; font-size:14px; text-align:center; margin-bottom: 1rem;">
-    DEBUG MARKETPLACE ACTIVE
-  </p>
-
-  <!-- Top navigation -->
-  <header>
-    <div class="brand">AutoMart</div>
-    <nav>
-      <a href="signup.html">Sign Up</a>
-      <a href="signin.html">Sign In</a>
-      <a href="post_car.html">Post Ad</a>
-      <a href="marketplace.html">Marketplace</a>
-      <a href="orders.html">Orders</a>
-      <a href="admin.html">Admin</a>
-    </nav>
-  </header>
-
-  <!-- Car listings / filters -->
-  <section class="wide-card">
-    <h1>Available Cars</h1>
-    <h2>Filter unsold listings</h2>
-
-    <!-- FILTER BAR -->
-    <div class="filters-row">
-      <div class="form-group">
-        <label>Min Price ($)</label>
-        <input id="minPrice" type="number" placeholder="e.g. 2000" />
+    <section class="wide-card section-stack">
+      <div>
+        <h1>Marketplace</h1>
+        <h2>Live unsold listings from the API</h2>
       </div>
 
-      <div class="form-group">
-        <label>Max Price ($)</label>
-        <input id="maxPrice" type="number" placeholder="e.g. 10000" />
+      <div class="filters-row">
+        <div class="form-group">
+          <label>Min Price ($)</label>
+          <input id="minPrice" type="number" min="0" placeholder="e.g. 2000" />
+        </div>
+        <div class="form-group">
+          <label>Max Price ($)</label>
+          <input id="maxPrice" type="number" min="0" placeholder="e.g. 10000" />
+        </div>
+        <div class="form-group">
+          <label>Manufacturer</label>
+          <input id="manufacturerFilter" placeholder="e.g. Toyota" />
+        </div>
+        <div class="form-group">
+          <label>State</label>
+          <select id="stateFilter">
+            <option value="">Any</option>
+            <option value="new">New</option>
+            <option value="used">Used</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Body Type</label>
+          <input id="bodyTypeFilter" placeholder="e.g. SUV" />
+        </div>
+        <div class="form-group">
+          <label>Sort</label>
+          <select id="sortFilter">
+            <option value="newest">Newest</option>
+            <option value="price_asc">Price: Low to High</option>
+            <option value="price_desc">Price: High to Low</option>
+          </select>
+        </div>
       </div>
 
-      <div class="form-group">
-        <label>Manufacturer</label>
-        <input id="manufacturerFilter" placeholder="e.g. Toyota" />
+      <div style="display:flex; gap:.75rem; flex-wrap:wrap;">
+        <button class="primary-btn" id="applyFiltersBtn" style="max-width:220px;">Apply Filters</button>
+        <button class="primary-btn" id="refreshBtn" style="max-width:180px; background:#334155; color:#f8fafc;">Refresh</button>
       </div>
 
-      <div class="form-group">
-        <label>State</label>
-        <select id="stateFilter">
-          <option value="">Any</option>
-          <option value="new">New</option>
-          <option value="used">Used</option>
-        </select>
+      <div class="table-scroll">
+        <table id="carsTable">
+          <thead>
+            <tr>
+              <th>#ID</th>
+              <th>Make / Model</th>
+              <th>Price ($)</th>
+              <th>State</th>
+              <th>Status</th>
+              <th>Body Type</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <p id="emptyState" class="empty-state" hidden>No cars match your current filters.</p>
       </div>
 
-      <div class="form-group">
-        <label>Body Type</label>
-        <select id="bodyTypeFilter">
-          <option value="">Any</option>
-          <option value="sedan">Sedan</option>
-          <option value="suv">SUV</option>
-          <option value="truck">Truck</option>
-          <option value="van">Van</option>
-          <option value="hatch">Hatchback</option>
-        </select>
-      </div>
-    </div>
-
-    <button class="primary-btn" id="applyFiltersBtn" style="max-width:200px;">
-      Apply Filters
-    </button>
-
-    <!-- TABLE OF CARS -->
-    <div class="table-scroll" style="margin-top:1.5rem;">
-      <table id="carsTable">
-        <thead>
-          <tr>
-            <th>#ID</th>
-            <th>Make / Model</th>
-            <th>Price ($)</th>
-            <th>State</th>
-            <th>Status</th>
-            <th>Body Type</th>
-            <th>View</th>
-          </tr>
-        </thead>
-        <tbody>
-          <!-- Will be populated by JavaScript -->
-        </tbody>
-      </table>
-    </div>
-
-    <!-- We show the simulated API call here -->
-    <div id="marketFeedback" class="feedback-box"></div>
-  </section>
-
-  <!-- View a specific car -->
-  <section class="main-card">
-    <h1>View Car Details</h1>
-    <form id="viewCarForm">
-      <div class="form-group">
-        <label>Car ID</label>
-        <input name="car_id" required placeholder="Enter car ID" />
-      </div>
-      <button class="primary-btn" type="submit">Fetch Car</button>
-    </form>
-
-    <!-- We show the single-car API call here -->
-    <div id="singleCarFeedback" class="feedback-box"></div>
-  </section>
+      <div id="marketFeedback" class="feedback-box"></div>
+    </section>
+  </div>
 
   <script>
-    // Simple popup so you KNOW this exact file's JS ran
-    alert("JS is running on marketplace.html");
+    const API_BASE = "http://127.0.0.1:5000/api/v1/car";
 
-    // Demo inventory data (pretend it came from /api/v1/car?status=available)
-    const demoCars = [
-      {
-        id: 1,
-        manufacturer: "Toyota",
-        model: "Corolla",
-        price: 5000,
-        state: "used",
-        status: "available",
-        body_type: "sedan"
-      },
-      {
-        id: 2,
-        manufacturer: "Tesla",
-        model: "Model 3",
-        price: 15000,
-        state: "new",
-        status: "available",
-        body_type: "sedan"
-      },
-      {
-        id: 3,
-        manufacturer: "Nissan",
-        model: "X-Trail",
-        price: 10000,
-        state: "used",
-        status: "sold",
-        body_type: "suv"
-      }
-    ];
+    function readFilters() {
+      return {
+        min_price: document.getElementById("minPrice").value,
+        max_price: document.getElementById("maxPrice").value,
+        manufacturer: document.getElementById("manufacturerFilter").value.trim(),
+        state: document.getElementById("stateFilter").value,
+        body_type: document.getElementById("bodyTypeFilter").value.trim(),
+        sort: document.getElementById("sortFilter").value,
+      };
+    }
 
-    // Renders the table rows using a list of cars
-    function renderCars(carsList) {
+    function toQuery(filters) {
+      const params = new URLSearchParams();
+      Object.entries(filters).forEach(([key, value]) => {
+        if (value !== "" && value !== null && value !== undefined) {
+          params.append(key, value);
+        }
+      });
+      return params.toString();
+    }
+
+    function renderCars(cars) {
       const tbody = document.querySelector("#carsTable tbody");
+      const empty = document.getElementById("emptyState");
       tbody.innerHTML = "";
 
-      carsList.forEach(car => {
+      if (!cars.length) {
+        empty.hidden = false;
+        return;
+      }
+
+      empty.hidden = true;
+      cars.forEach((car) => {
         const tr = document.createElement("tr");
         tr.innerHTML = `
           <td>${car.id}</td>
           <td>${car.manufacturer} ${car.model}</td>
-          <td>$${car.price}</td>
+          <td>$${Number(car.price).toLocaleString()}</td>
           <td>${car.state}</td>
-          <td>
-            <span class="status-pill ${
-              car.status === "available" ? "status-available" : "status-sold"
-            }">${car.status}</span>
-          </td>
+          <td><span class="status-pill ${car.status === "available" ? "status-available" : "status-sold"}">${car.status}</span></td>
           <td>${car.body_type}</td>
-          <td>
-            <button class="primary-btn"
-              style="padding:.4rem .6rem;font-size:.7rem;width:auto;">
-              View
-            </button>
-          </td>
         `;
         tbody.appendChild(tr);
       });
     }
 
-    // Initial render of the full list
-    renderCars(demoCars);
+    async function loadCars() {
+      const feedback = document.getElementById("marketFeedback");
+      const query = toQuery(readFilters());
+      const url = query ? `${API_BASE}?${query}` : API_BASE;
 
-    // When you click "Apply Filters", we:
-    // 1. Build what the backend query string would look like
-    // 2. Filter demoCars locally (so you SEE the change)
-    document.getElementById("applyFiltersBtn").addEventListener("click", () => {
-      const q = {
-        status: "available", // We only want unsold cars
-        min_price: document.getElementById("minPrice").value,
-        max_price: document.getElementById("maxPrice").value,
-        manufacturer: document.getElementById("manufacturerFilter").value,
-        state: document.getElementById("stateFilter").value,
-        body_type: document.getElementById("bodyTypeFilter").value
-      };
+      try {
+        feedback.className = "feedback-box";
+        feedback.textContent = "Loading live listings...";
 
-      // Show the simulated API request that would be sent:
-      // /api/v1/car?status=available&min_price=... etc.
-      document.getElementById("marketFeedback").textContent =
-        "🔎 GET /api/v1/car with filters -> " + JSON.stringify(q);
+        const res = await fetch(url);
+        const body = await res.json();
 
-      // Locally filter demoCars just for visual feedback
-      const filtered = demoCars.filter(car => {
-        if (q.status && car.status !== q.status) return false;
-        if (q.min_price && car.price < Number(q.min_price)) return false;
-        if (q.max_price && car.price > Number(q.max_price)) return false;
-        if (q.manufacturer &&
-            car.manufacturer.toLowerCase() !== q.manufacturer.toLowerCase()) {
-          return false;
+        if (!res.ok) {
+          throw new Error(body.error || "Unable to load cars");
         }
-        if (q.state && car.state !== q.state) return false;
-        if (q.body_type && car.body_type !== q.body_type) return false;
-        return true;
-      });
 
-      // Re-render the table with only the filtered cars
-      renderCars(filtered);
-    });
+        renderCars(body.cars || []);
+        feedback.className = "feedback-box success";
+        feedback.textContent = `Loaded ${body.count} listings (total available: ${body.total}).`;
+      } catch (err) {
+        renderCars([]);
+        feedback.className = "feedback-box error";
+        feedback.textContent = `Error: ${err.message}. Ensure backend is running on 127.0.0.1:5000.`;
+      }
+    }
 
-    // "View Car Details" form:
-    // This simulates GET /api/v1/car/:id
-    document.getElementById("viewCarForm").addEventListener("submit", e => {
-      e.preventDefault();
+    document.getElementById("applyFiltersBtn").addEventListener("click", loadCars);
+    document.getElementById("refreshBtn").addEventListener("click", loadCars);
 
-      const data = Object.fromEntries(new FormData(e.target).entries());
-
-      // Show the mock request
-      document.getElementById("singleCarFeedback").textContent =
-        "🚘 GET /api/v1/car/" + data.car_id;
-
-      // Later, when backend is running:
-      // fetch(`/api/v1/car/${data.car_id}`)
-      //   .then(res => res.json())
-      //   .then(json => { ...display json... })
-    });
+    loadCars();
   </script>
-
 </body>
 </html>

--- a/automart/UI/style.css
+++ b/automart/UI/style.css
@@ -29,6 +29,11 @@ body {
   flex-direction: column;
 }
 
+.page-shell {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+}
+
 /* Top nav bar */
 
 header {
@@ -37,6 +42,7 @@ header {
   gap: .5rem 1rem;
   align-items: center;
   margin-bottom: 2rem;
+  justify-content: space-between;
 }
 
 header .brand {
@@ -56,6 +62,12 @@ header nav a {
 header nav a:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+header nav a.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(56, 189, 248, 0.1);
 }
 
 /* Cards / panels */
@@ -78,6 +90,11 @@ header nav a:hover {
   width: 100%;
   margin-bottom: 2rem;
   overflow-x: auto;
+}
+
+.section-stack {
+  display: grid;
+  gap: 1rem;
 }
 
 /* Headings */
@@ -207,6 +224,12 @@ th {
   line-height: 1.4;
   color: var(--accent);
   min-height: 1.2rem;
+}
+
+.empty-state {
+  color: var(--text-dim);
+  padding: 1rem 0;
+  font-size: 0.9rem;
 }
 .feedback-box.error {
   color: var(--danger);

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,12 @@ users = []
 cars = []
 orders = []
 
+# Fast lookup indexes for the in-memory data.
+users_by_id = {}
+users_by_email = {}
+cars_by_id = {}
+orders_by_id = {}
+
 
 auth_bp = Blueprint("auth", __name__, url_prefix="/api/v1/auth")
 car_bp = Blueprint("car", __name__, url_prefix="/api/v1/car")
@@ -37,7 +43,7 @@ def _now_iso() -> str:
 
 
 def _find_user(user_id: int):
-    return next((u for u in users if u["id"] == user_id), None)
+    return users_by_id.get(user_id)
 
 
 def _auth_user():
@@ -52,7 +58,7 @@ def _auth_user():
 
 
 def _find_car(car_id: int):
-    return next((c for c in cars if c["id"] == car_id), None)
+    return cars_by_id.get(car_id)
 
 
 def _serialize_car(car):
@@ -92,7 +98,7 @@ def signup():
         return jsonify({"error": "Missing required fields", "missing_fields": missing}), 400
 
     email = data["email"].strip().lower()
-    if any(u["email"] == email for u in users):
+    if email in users_by_email:
         return jsonify({"error": "User already exists"}), 400
 
     is_admin = False
@@ -113,6 +119,8 @@ def signup():
         "password_hash": generate_password_hash(data["password"], method="pbkdf2:sha256"),
     }
     users.append(user)
+    users_by_id[user_id] = user
+    users_by_email[email] = user
 
     access_token = create_access_token(identity=str(user["id"]), additional_claims={"is_admin": user["is_admin"]})
     return (
@@ -143,7 +151,7 @@ def signin():
     if not email or not password:
         return jsonify({"error": "Email and password are required"}), 400
 
-    user = next((u for u in users if u["email"] == email), None)
+    user = users_by_email.get(email)
     if not user or not check_password_hash(user["password_hash"], password):
         return jsonify({"error": "Invalid email or password"}), 400
 
@@ -200,6 +208,7 @@ def create_car():
         "body_type": str(data["body_type"]).strip(),
     }
     cars.append(car)
+    cars_by_id[car_id] = car
     return jsonify({"message": "Car ad posted", "car": _serialize_car(car)}), 201
 
 
@@ -213,16 +222,53 @@ def get_car(car_id: int):
 
 @car_bp.route("", methods=["GET"])
 def get_unsold_cars():
+    page = request.args.get("page", default=1, type=int)
+    limit = request.args.get("limit", default=20, type=int)
     min_price = request.args.get("min_price", type=float)
     max_price = request.args.get("max_price", type=float)
+    manufacturer = request.args.get("manufacturer", default="", type=str).strip().lower()
+    state = request.args.get("state", default="", type=str).strip().lower()
+    body_type = request.args.get("body_type", default="", type=str).strip().lower()
+    sort = request.args.get("sort", default="newest", type=str).strip().lower()
+
+    if page < 1 or limit < 1 or limit > 100:
+        return jsonify({"error": "page must be >= 1 and limit must be between 1 and 100"}), 400
 
     filtered = [car for car in cars if car["status"] == "available"]
     if min_price is not None:
         filtered = [car for car in filtered if car["price"] >= min_price]
     if max_price is not None:
         filtered = [car for car in filtered if car["price"] <= max_price]
+    if manufacturer:
+        filtered = [car for car in filtered if car["manufacturer"].strip().lower() == manufacturer]
+    if state:
+        filtered = [car for car in filtered if car["state"] == state]
+    if body_type:
+        filtered = [car for car in filtered if car["body_type"].strip().lower() == body_type]
 
-    return jsonify({"cars": [_serialize_car(car) for car in filtered], "count": len(filtered)}), 200
+    if sort == "price_asc":
+        filtered = sorted(filtered, key=lambda car: car["price"])
+    elif sort == "price_desc":
+        filtered = sorted(filtered, key=lambda car: car["price"], reverse=True)
+    else:
+        filtered = sorted(filtered, key=lambda car: car["id"], reverse=True)
+
+    total = len(filtered)
+    start = (page - 1) * limit
+    paged = filtered[start : start + limit]
+
+    return (
+        jsonify(
+            {
+                "cars": [_serialize_car(car) for car in paged],
+                "count": len(paged),
+                "total": total,
+                "page": page,
+                "limit": limit,
+            }
+        ),
+        200,
+    )
 
 
 @car_bp.route("/<int:car_id>/status", methods=["PATCH"])
@@ -284,6 +330,8 @@ def create_order():
         return jsonify({"error": "Car not found"}), 404
     if car["status"] != "available":
         return jsonify({"error": "Cannot place order for a sold car"}), 400
+    if car["owner"] == user["id"]:
+        return jsonify({"error": "Cannot place an order on your own car"}), 400
 
     try:
         offered = float(data.get("amount"))
@@ -303,6 +351,7 @@ def create_order():
         "price_offered": round(offered, 2),
     }
     orders.append(order)
+    orders_by_id[order_id] = order
     return jsonify({"message": "Order created", "order": _serialize_order(order)}), 201
 
 
@@ -313,7 +362,7 @@ def update_order_price(order_id: int):
     if not user:
         return jsonify({"error": "User not found"}), 401
 
-    order = next((item for item in orders if item["id"] == order_id), None)
+    order = orders_by_id.get(order_id)
     if not order:
         return jsonify({"error": "Order not found"}), 404
     if order["buyer"] != user["id"]:
@@ -358,6 +407,7 @@ def delete_car(car_id: int):
         return jsonify({"error": "Car not found"}), 404
 
     cars.remove(car)
+    cars_by_id.pop(car_id, None)
     return jsonify({"message": "Car ad deleted"}), 200
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -11,7 +11,16 @@ BASE_DIR = pathlib.Path(__file__).resolve().parents[1]
 if str(BASE_DIR) not in sys.path:
     sys.path.insert(0, str(BASE_DIR))
 
-from app import cars, create_app, orders, users  # noqa: E402
+from app import (  # noqa: E402
+    cars,
+    cars_by_id,
+    create_app,
+    orders,
+    orders_by_id,
+    users,
+    users_by_email,
+    users_by_id,
+)
 
 
 @pytest.fixture
@@ -19,6 +28,10 @@ def client():
     users.clear()
     cars.clear()
     orders.clear()
+    users_by_id.clear()
+    users_by_email.clear()
+    cars_by_id.clear()
+    orders_by_id.clear()
 
     app = create_app()
     app.config["TESTING"] = True
@@ -117,6 +130,7 @@ def test_seller_car_lifecycle_and_filter(client):
     filter_res = client.get("/api/v1/car?min_price=14000&max_price=14600")
     assert filter_res.status_code == 200
     assert filter_res.get_json()["count"] == 1
+    assert filter_res.get_json()["total"] == 1
 
     sold_res = client.patch(
         f"/api/v1/car/{car_id}/status",
@@ -216,3 +230,46 @@ def test_non_admin_cannot_delete_car(client):
     forbidden = client.delete(f"/api/v1/car/{car_id}", headers=auth_headers(buyer_token))
     assert forbidden.status_code == 403
     assert forbidden.get_json()["error"] == "Admin access required"
+
+
+def test_marketplace_advanced_filters_and_pagination(client):
+    seller_token = signup_and_token(client, "seller5@example.com")
+    payloads = [
+        {"state": "used", "price": 13000, "manufacturer": "Toyota", "model": "Rav4", "body_type": "SUV"},
+        {"state": "used", "price": 7000, "manufacturer": "Toyota", "model": "Yaris", "body_type": "Hatchback"},
+        {"state": "new", "price": 23000, "manufacturer": "Mazda", "model": "CX5", "body_type": "SUV"},
+    ]
+    for payload in payloads:
+        res = client.post("/api/v1/car", json=payload, headers=auth_headers(seller_token))
+        assert res.status_code == 201
+
+    res = client.get("/api/v1/car?manufacturer=toyota&state=used&sort=price_asc&page=1&limit=1")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["count"] == 1
+    assert body["total"] == 2
+    assert body["cars"][0]["model"] == "Yaris"
+
+
+def test_cannot_order_own_car(client):
+    seller_token = signup_and_token(client, "seller6@example.com")
+    car_res = client.post(
+        "/api/v1/car",
+        json={
+            "state": "used",
+            "price": 5400,
+            "manufacturer": "Ford",
+            "model": "Fiesta",
+            "body_type": "Hatchback",
+        },
+        headers=auth_headers(seller_token),
+    )
+    car_id = car_res.get_json()["car"]["id"]
+
+    order_res = client.post(
+        "/api/v1/order",
+        json={"car_id": car_id, "amount": 5300},
+        headers=auth_headers(seller_token),
+    )
+    assert order_res.status_code == 400
+    assert order_res.get_json()["error"] == "Cannot place an order on your own car"


### PR DESCRIPTION
### Motivation
- Reduce request-time cost of repeated list scans by adding O(1) lookups for users, cars, and orders to support a production-ready in-memory store.
- Replace the marketplace demo UX with a live, API-driven screen so the frontend can show real data and support filtering/sorting/pagination.
- Add common marketplace features (filters, sorting, pagination) and enforce a simple business rule to prevent sellers ordering their own listings.

### Description
- Introduced fast in-memory indexes: `users_by_id`, `users_by_email`, `cars_by_id`, and `orders_by_id`, and wired them into signup/signin, lookups, create/delete flows in `backend/app.py`.
- Expanded `GET /api/v1/car` to accept `manufacturer`, `state`, `body_type`, `sort`, `page`, and `limit` parameters and return pagination metadata (`count`, `total`, `page`, `limit`) with input validation.
- Added guard in `create_order` to reject orders where `car["owner"] == user["id"]` and used `orders_by_id` for efficient order lookups and updates.
- Replaced the demo JS in `automart/UI/marketplace.html` with an API-backed implementation that reads filters, composes query strings, handles loading/error/empty states, and renders results; updated `automart/UI/style.css` for layout, active nav state, and empty-state styling.
- Updated tests in `backend/tests/test_auth.py` to clear the new indexes and added tests for advanced filtering/pagination and the self-order rejection behavior.

### Testing
- Ran the backend test suite with `pytest -q` (from `backend/`), which succeeded: `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0700290fc8332908c954e41f0dae3)